### PR TITLE
docs(readme.md): correct readme links

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,7 +30,7 @@ Flags:
 Use "pomscan [command] --help" for more information about a command.
 ```
 
-For command documentation please read the [CLI documentation](./docs/_index.md).
+For command documentation please read the [CLI reference](./docs/_index.md).
 
 **Example**
 


### PR DESCRIPTION
This PR set correct link name to the CLI reference page.